### PR TITLE
Change agar food rendering from circles to stars

### DIFF
--- a/static/js/renderer.js
+++ b/static/js/renderer.js
@@ -21,12 +21,35 @@ export function resizeCanvas() {
     canvas.height = window.innerHeight;
 }
 
-function drawCircle(x, y, value, color, isFood) {
-    const size = isFood ? value : getSize(value);
+function drawStar(x, y, radius, points, color) {
+    const innerRadius = radius * 0.4;
     ctx.beginPath();
-    ctx.arc(x, y, size, 0, Math.PI * 2);
+    for (let i = 0; i < points * 2; i++) {
+        const r = i % 2 === 0 ? radius : innerRadius;
+        const angle = (Math.PI * i) / points - Math.PI / 2;
+        const px = x + r * Math.cos(angle);
+        const py = y + r * Math.sin(angle);
+        if (i === 0) {
+            ctx.moveTo(px, py);
+        } else {
+            ctx.lineTo(px, py);
+        }
+    }
+    ctx.closePath();
     ctx.fillStyle = color;
     ctx.fill();
+}
+
+function drawCircle(x, y, value, color, isFood) {
+    const size = isFood ? value : getSize(value);
+    if (isFood) {
+        drawStar(x, y, size, 5, color);
+    } else {
+        ctx.beginPath();
+        ctx.arc(x, y, size, 0, Math.PI * 2);
+        ctx.fillStyle = color;
+        ctx.fill();
+    }
 }
 
 function drawCellWithName(x, y, score, color, name) {


### PR DESCRIPTION
## Summary

Replaces the circular food (agar) rendering with 5-pointed stars. Adds a `drawStar(x, y, radius, points, color)` helper that draws a star polygon, and updates `drawCircle` to dispatch to it when `isFood` is true. Player and AI cells remain as circles.

![Stars rendering in game](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctMzE2MTYyNTFjZDBiNDEzYzlmNzM5NGQ1ZDBlMTUzMmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctMzE2MTYyNTFjZDBiNDEzYzlmNzM5NGQ1ZDBlMTUzMmUvZTZlMjk1ZGItZTYyZC00MzBlLTlkYjItMDE0NDBkOTEyMjhhIiwiaWF0IjoxNzgxNjU5MzAxLCJleHAiOjE3ODIyNjQxMDEsImZpbGVuYW1lIjoic2NyZWVuc2hvdF8xMjhmYjU5NGU3NDM0Y2QzOTU5ZDk1ZjhjNWRjZDFlNy5wbmcifQ.Mi2Iqih1KYqzT3mejdS0Y1j3fiS_CnzY7b07unE20TA)

Link to Devin session: https://app.devin.ai/sessions/e2ab888f9c144784a1bb36e9dc79fda1